### PR TITLE
Add ability to configure page template directory using typicms config file

### DIFF
--- a/src/Services/TypiCMS.php
+++ b/src/Services/TypiCMS.php
@@ -142,8 +142,9 @@ class TypiCMS
      *
      * @return array
      */
-    public function templates($directory = 'resources/views/vendor/pages/public')
+    public function templates($directory = null)
     {
+        $directory = $directory ?: config('typicms.template_dir', 'resources/views/vendor/pages/public');
         $templates = [];
         try {
             $files = File::allFiles(base_path($directory));


### PR DESCRIPTION
This will use the key `template_dir` in the typicms config file if no $directory var is passed in, and if no key is found fall back to 'resources/views/vendor/pages/public'. 

This is in conjunction with a commit to Base https://github.com/eahrold/Base/commit/b079315693dcf1de33fb99aaed9b4e833a001be4
