### PR TITLE
Update HtmlCacheEvents.php

### DIFF
--- a/src/Traits/HtmlCacheEvents.php
+++ b/src/Traits/HtmlCacheEvents.php
@@ -11,10 +11,8 @@ trait HtmlCacheEvents
      *
      * @return void
      */
-    public static function boot()
+    public static function bootHtmlCacheEvents()
     {
-        parent::boot();
-
         if (config('typicms.html_cache')) {
             static::saved(function ($model) {
                 Artisan::call('clear-html');


### PR DESCRIPTION
I tried adding another trait with boot method and of course it didn't work. I found out that Model::boot calls Model::bootTraits which looks for a method named 'boot'.class_basename($trait) and calls that. So naming the boot method bootHtmlCacheEvents is more appropriate I guess.
