### PR TITLE
Update _galleries-fieldset.blade.php

### DIFF
--- a/src/resources/views/admin/_galleries-fieldset.blade.php
+++ b/src/resources/views/admin/_galleries-fieldset.blade.php
@@ -2,7 +2,7 @@
 We need an empty element to allow to deselect all items
 and have a galleries key in the post data
 --}}
-{!! BootForm::hidden('galleries') !!}
+{!! BootForm::hidden('galleries')->value('') !!}
 {!! BootForm::select(
         trans('validation.attributes.galleries'),
         'galleries[]',


### PR DESCRIPTION
When there is a gallery (galleries) assigned to a page (or anything) BootForm::hidden('galleries') takes the $model->galleries which in this case is a Collection. While the form builder tries to escape the value of the hidden input it checks that it is not a string and returns the whole collection. It is then serialized to a json and the value of the hidden input contains quotes which break the HTML markup.
As far as I can see in the comment the purpose of this hidden input is just to pass empty value so if you remove all galleries it is identified as a change. I think setting an empty value for the hidden field does the trick.
