### PR TITLE
Conditionnaly displays TypiCMS::baseline()

### DIFF
--- a/src/resources/views/public/master.blade.php
+++ b/src/resources/views/public/master.blade.php
@@ -55,7 +55,9 @@
             @section('site-title')
             <div class="site-title">@include('core::public._site-title')</div>
             @show
+            @if(TypiCMS::baseline())
             <p class="site-baseline">{{ TypiCMS::baseline() }}</p>
+            @endif
         </header>
         @show
 


### PR DESCRIPTION
Paragraph for TypiCMS::baseline() is only displayed if not empty in master.blade.php