### PR TITLE
Fix SQL injection risk in search and translation queries

### DIFF
--- a/src/Http/Controllers/SearchPublicController.php
+++ b/src/Http/Controllers/SearchPublicController.php
@@ -40,24 +40,21 @@ final class SearchPublicController extends BasePublicController
                     foreach ($columns as $column) {
                         $query->orWhere(function ($query) use ($words, $column, $model): void {
                             foreach ($words as $word) {
-                                $word = addslashes($word);
                                 if (in_array($column, (array) $model->translatable, true)) {
                                     $query
                                         ->published()
                                         ->whereRaw(
                                             'JSON_UNQUOTE(JSON_EXTRACT(`'
                                             .$column
-                                            .'`, \'$.'
-                                            .app()->getLocale()
-                                            ."')) LIKE '%"
-                                            .$word
-                                            ."%' COLLATE utf8mb4_unicode_ci",
+                                            .'`, ?)) LIKE ? COLLATE utf8mb4_unicode_ci',
+                                            ['$.'.app()->getLocale(), '%'.$word.'%'],
                                         );
                                 } else {
                                     $query
                                         ->published()
                                         ->whereRaw(
-                                            '`'.$column."` LIKE '%".$word."%' COLLATE utf8mb4_unicode_ci",
+                                            '`'.$column.'` LIKE ? COLLATE utf8mb4_unicode_ci',
+                                            ['%'.$word.'%'],
                                         );
                                 }
                             }
@@ -67,28 +64,21 @@ final class SearchPublicController extends BasePublicController
                                 $query->published();
                                 $query->whereHas('sections', function ($query) use ($words, $column, $model): void {
                                     foreach ($words as $word) {
-                                        $word = addslashes($word);
                                         if (in_array($column, (array) $model->translatable, true)) {
                                             $query
                                                 ->published()
                                                 ->whereRaw(
                                                     'JSON_UNQUOTE(JSON_EXTRACT(`'
                                                     .$column
-                                                    .'`, \'$.'
-                                                    .app()->getLocale()
-                                                    ."')) LIKE '%"
-                                                    .$word
-                                                    ."%' COLLATE utf8mb4_unicode_ci",
+                                                    .'`, ?)) LIKE ? COLLATE utf8mb4_unicode_ci',
+                                                    ['$.'.app()->getLocale(), '%'.$word.'%'],
                                                 );
                                         } else {
                                             $query
                                                 ->published()
                                                 ->whereRaw(
-                                                    '`'
-                                                    .$column
-                                                    ."` LIKE '%"
-                                                    .$word
-                                                    ."%' COLLATE utf8mb4_unicode_ci",
+                                                    '`'.$column.'` LIKE ? COLLATE utf8mb4_unicode_ci',
+                                                    ['%'.$word.'%'],
                                                 );
                                         }
                                     }

--- a/src/Loaders/MixedLoader.php
+++ b/src/Loaders/MixedLoader.php
@@ -41,7 +41,7 @@ class MixedLoader extends FileLoader
     {
         try {
             return Translation::query()
-                ->selectRaw("JSON_UNQUOTE(JSON_EXTRACT(`translation`, '$.".$locale."')) AS translated")
+                ->selectRaw('JSON_UNQUOTE(JSON_EXTRACT(`translation`, ?)) AS translated', ['$.'.$locale])
                 ->addSelect('key')
                 ->pluck('translated', 'key')
                 ->all();


### PR DESCRIPTION
Replace fragile addslashes() string concatenation in SearchPublicController with parameterized query bindings, matching the safe pattern already used in FilterOr. addslashes() is not a reliable SQL-escaping mechanism (e.g. it can be bypassed under MySQL's NO_BACKSLASH_ESCAPES sql_mode), so user-supplied search terms could break out of the quoted LIKE literal.

Also parameterize the locale value interpolated into the raw JSON_EXTRACT query in MixedLoader for defense in depth.

https://claude.ai/code/session_01EUUnydptJJw8Az5AAVQ1r3