### PR TITLE
SVG Sanitizer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         }
     ],
     "require": {
+        "enshrined/svg-sanitize": "^0.22.0",
         "laravel/framework": "~12.0"
     },
     "autoload": {

--- a/src/Services/FileUploader.php
+++ b/src/Services/FileUploader.php
@@ -2,6 +2,7 @@
 
 namespace TypiCMS\Modules\Core\Services;
 
+use enshrined\svgSanitize\Sanitizer;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Storage;
@@ -30,6 +31,10 @@ class FileUploader
 
         $filename = "$filenameWithoutExtension.$extension";
 
+        if ($extension === 'svg') {
+            $this->sanitizeSvg($file);
+        }
+
         $dimensions = getimagesize($file);
         [$width, $height] = $dimensions !== false ? $dimensions : [0, 0];
 
@@ -47,6 +52,17 @@ class FileUploader
         $type = Arr::get(config('file.types'), $extension, 'd');
 
         return ['filesize' => $filesize, 'mimetype' => $mimetype, 'extension' => $extension, 'filename' => $filename, 'width' => $width, 'height' => $height, 'path' => $path, 'type' => $type];
+    }
+
+    private function sanitizeSvg(UploadedFile $file): void
+    {
+        $sanitizer = new Sanitizer();
+        $sanitizedContent = $sanitizer->sanitize($file->getContent());
+
+        file_put_contents(
+            $file->getPathname(),
+            $sanitizedContent ?: ''
+        );
     }
 
     private function correctImageOrientation(UploadedFile $file): void


### PR DESCRIPTION
Sanitize SVG uploads to prevent stored XSS (CVE-2026-27621 / GHSA-xfvg-8v67-j7wp). Backport of d480a0b to the 15.0 line.

Require enshrined/svg-sanitize