### PR TITLE
Harden dashboard welcome message against XSS

### DIFF
--- a/src/Http/Controllers/DashboardAdminController.php
+++ b/src/Http/Controllers/DashboardAdminController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TypiCMS\Modules\Core\Http\Controllers;
 
+use DOMDocument;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Http;
 use Illuminate\View\View;
@@ -34,10 +35,73 @@ final class DashboardAdminController extends BaseAdminController
         $body = rescue(fn () => Http::timeout(2)->get($url)->body());
 
         if ($body !== null) {
-            return strip_tags($body, '<a><strong><em><br><p><ul><ol><li>');
+            return $this->sanitizeHtml($body);
         }
 
         return $fallback;
+    }
+
+    /**
+     * Sanitize remotely fetched HTML before it is rendered unescaped in the
+     * dashboard. Beyond limiting the allowed tags, every attribute is removed
+     * so that event handlers (onclick, onerror, …) and javascript: URIs cannot
+     * be smuggled in through a compromised or man-in-the-middled upstream. Only
+     * a safe href is restored on links.
+     */
+    private function sanitizeHtml(string $html): string
+    {
+        $html = strip_tags($html, '<a><strong><em><br><p><ul><ol><li>');
+
+        if (mb_trim($html) === '') {
+            return '';
+        }
+
+        $dom = new DOMDocument;
+        libxml_use_internal_errors(true);
+        $dom->loadHTML(
+            '<?xml encoding="UTF-8" ?><body>'.$html.'</body>',
+            LIBXML_NOERROR | LIBXML_NOWARNING,
+        );
+        libxml_clear_errors();
+
+        foreach (iterator_to_array($dom->getElementsByTagName('*')) as $element) {
+            $href = mb_strtolower($element->tagName) === 'a' ? $element->getAttribute('href') : null;
+
+            while ($element->attributes->length > 0) {
+                $element->removeAttribute($element->attributes->item(0)->nodeName);
+            }
+
+            if ($href !== null && $this->isSafeHref($href)) {
+                $element->setAttribute('href', $href);
+            }
+        }
+
+        $body = $dom->getElementsByTagName('body')->item(0);
+        $output = '';
+        if ($body) {
+            foreach ($body->childNodes as $child) {
+                $output .= (string) $dom->saveHTML($child);
+            }
+        }
+
+        return mb_trim($output);
+    }
+
+    private function isSafeHref(string $href): bool
+    {
+        $href = mb_trim($href);
+
+        if ($href === '') {
+            return false;
+        }
+
+        if (str_starts_with($href, '/') || str_starts_with($href, '#')) {
+            return true;
+        }
+
+        $scheme = mb_strtolower((string) parse_url($href, PHP_URL_SCHEME));
+
+        return in_array($scheme, ['http', 'https', 'mailto'], true);
     }
 
     private function isAllowedUrl(string $url): bool


### PR DESCRIPTION
## Summary

Second-pass security fix following the search SQL-injection fix (#104).

The admin dashboard renders the **welcome message** unescaped:

```blade
<div class="dashboard-body">{!! $welcomeMessage !!}</div>
```

The message is fetched from a remote URL (`WELCOME_MESSAGE_URL`) and was only filtered with `strip_tags($body, '<a>...')`. `strip_tags()` restricts *tags* but **keeps their attributes**, so the allowed tags could still carry:

- event handlers — `<a onmouseover=…>`, `<p onclick=…>`
- dangerous URIs — `<a href="javascript:…">`

If the configured upstream is compromised — or served over plain `http` and man-in-the-middled — this becomes **stored/reflected XSS executing in the admin panel** (full CMS takeover via an authenticated admin's session). The existing SSRF guard (`isAllowedUrl`) does not address the content of the response.

## Fix

`sanitizeHtml()` now:
1. Restricts tags with `strip_tags` (unchanged allowlist).
2. Parses the result with `DOMDocument` and **removes every attribute** from every element.
3. Restores only a **safe `href`** on `<a>` (http/https/mailto, or relative/anchor) — `javascript:`/`data:`/etc. are dropped.

DOM-based rebuilding (rather than regex) avoids attribute-parsing bypasses. Legitimate formatting and safe links are preserved; UTF-8 content is handled correctly.

## Verification

Sanitizer logic exercised against representative inputs:

| Input | Output |
|---|---|
| `<a href="https://x.com" onclick="alert(1)">link</a>` | `<a href="https://x.com">link</a>` |
| `<a href="javascript:alert(1)">x</a>` | `<a>x</a>` |
| `<a href="JaVaScRiPt:alert(1)">x</a>` | `<a>x</a>` |
| `<a href="mailto:a@b.com">mail</a>` | `<a href="mailto:a@b.com">mail</a>` |
| `<p onmouseover="alert(1)">hover</p>` | `<p>hover</p>` |
| `Café résumé <em>ok</em>` | `Café résumé <em>ok</em>` |

`php -l` passes (PHP 8.4). The package has no `vendor/` in this environment (the suite runs against a host app), so the full test suite wasn't run here.

https://claude.ai/code/session_01EUUnydptJJw8Az5AAVQ1r3

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUUnydptJJw8Az5AAVQ1r3)_