### PR TITLE
Allowlist user-supplied field names in HasSelectableFields

### DIFF
--- a/src/Traits/HasSelectableFields.php
+++ b/src/Traits/HasSelectableFields.php
@@ -11,6 +11,9 @@ use Illuminate\Database\Eloquent\Model;
 
 trait HasSelectableFields
 {
+    /** @var array<string, list<string>> */
+    private static array $selectableColumnsCache = [];
+
     private function isFieldTranslatable(string $field): bool
     {
         /** @var array<string> $translatable */
@@ -19,16 +22,39 @@ trait HasSelectableFields
         return in_array($field, $translatable, true);
     }
 
+    /**
+     * Real columns of the underlying table, used to allowlist requested fields.
+     *
+     * @param  Builder<Model>  $query
+     * @return list<string>
+     */
+    private function selectableColumns(Builder $query): array
+    {
+        $table = $this->getTable();
+
+        return self::$selectableColumnsCache[$table] ??= $query
+            ->getConnection()
+            ->getSchemaBuilder()
+            ->getColumnListing($table);
+    }
+
     /** @param Builder<Model> $query */
     #[Scope]
     protected function selectFields(Builder $query): void
     {
         $locale = request('locale', app()->getLocale());
         $fields = explode(',', (string) request()->string('fields.'.$this->getTable()));
+        $allowedColumns = $this->selectableColumns($query);
 
         foreach ($fields as $field) {
+            $field = mb_trim($field);
+
             if (! $this->isFieldTranslatable($field)) {
-                $query->addSelect($field);
+                // Never let a user-supplied value dictate a column name: only
+                // select columns that actually exist on the table.
+                if (in_array($field, $allowedColumns, true)) {
+                    $query->addSelect($field);
+                }
 
                 continue;
             }


### PR DESCRIPTION
## Summary

The `selectFields` scope (used by the Pages/Tags/Terms/Menus/… API controllers) built its SELECT list from the request-supplied `fields[<table>]` parameter and passed each value **directly to `addSelect()`**:

```php
$fields = explode(',', (string) request()->string('fields.'.$this->getTable()));

foreach ($fields as $field) {
    if (! $this->isFieldTranslatable($field)) {
        $query->addSelect($field); // ← user controls the column name
        ...
```

Letting user input dictate column names goes against [Laravel's own guidance](https://laravel.com/docs/queries) ("you should never allow user input to dictate the column names referenced by your queries"). Eloquent wraps identifiers, so this isn't trivially injectable on MySQL, but it's a fragile, defense-relies-on-the-grammar pattern and lets clients reference columns the endpoint never intended to expose.

## Fix

Restrict the **non-translatable** path to columns that actually exist on the table (resolved once per table via the schema builder and cached). Unknown/empty values are skipped instead of being handed to `addSelect()`.

The **translatable** path is unchanged — it was already gated by the model's developer-defined `$translatable` list (not user input), and its raw SQL uses bound parameters for the locale.

Behavior for legitimate requests is unchanged; only unknown/crafted field names are dropped.

## Verification

Logic exercised standalone:

| Requested `fields[...]` | Result |
|---|---|
| `id,created_at,position` | selects those columns |
| `title,status,slug` (translatable) | JSON-extract selects (unchanged) |
| `id, created_at , title` | whitespace tolerated |
| `id,(SELECT api_token FROM users)` | only `id` selected; the rest dropped |
| `password,secret_column` (non-existent) | dropped |

`php -l` passes (PHP 8.4). The package has no `vendor/` in this environment (the suite runs against a host app), so the full test suite wasn't run here.

https://claude.ai/code/session_01EUUnydptJJw8Az5AAVQ1r3

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUUnydptJJw8Az5AAVQ1r3)_