### PR TITLE
Fix FileUploader crash on non-image uploads

### DIFF
--- a/src/Services/FileUploader.php
+++ b/src/Services/FileUploader.php
@@ -34,12 +34,7 @@ class FileUploader
             $this->sanitizeSvg($file);
         }
 
-        [$width, $height] = getimagesize($file);
-        if ($extension === 'svg') {
-            preg_match("#viewbox=[\"']\d* \d* (\d*) (\d*)#i", $file->getContent(), $d);
-            $width = (float) $d[1];
-            $height = (float) $d[2];
-        }
+        [$width, $height] = $this->getImageDimensions($file, $extension);
 
         $filecounter = 1;
         while (Storage::disk($disk)->exists($path . '/' . $filename)) {
@@ -49,6 +44,29 @@ class FileUploader
         $type = Arr::get(config('file.types'), $extension, 'd');
 
         return compact('filesize', 'mimetype', 'extension', 'filename', 'width', 'height', 'path', 'type');
+    }
+
+    /** @return array{0: float|int, 1: float|int} */
+    private function getImageDimensions(UploadedFile $file, string $extension): array
+    {
+        if ($extension === 'svg') {
+            return $this->getSvgDimensions($file);
+        }
+
+        $dimensions = getimagesize($file);
+
+        return $dimensions !== false ? [$dimensions[0], $dimensions[1]] : [0, 0];
+    }
+
+    /** @return array{0: float, 1: float} */
+    private function getSvgDimensions(UploadedFile $file): array
+    {
+        preg_match("#viewbox=[\"']\d* \d* (\d*) (\d*)#i", $file->getContent(), $matches);
+
+        return [
+            (float) ($matches[1] ?? 0),
+            (float) ($matches[2] ?? 0),
+        ];
     }
 
     private function sanitizeSvg(UploadedFile $file): void


### PR DESCRIPTION
## Problem

Uploading any non-image file (PDF, doc, zip, …) through the files API throws:

```
Cannot use bool as array
vendor/typicms/core/src/Services/FileUploader.php:37
```

`getimagesize()` returns `false` for non-image files, and `[$width, $height] = getimagesize($file)` cannot destructure a `bool`.

## Fix

Extract the dimension resolution into `getImageDimensions()` / `getSvgDimensions()` helpers (inspired by the 17.x refactor of this class) and guard the `getimagesize() === false` case by falling back to `[0, 0]`. The SVG viewBox parsing is moved into its own helper and now defaults to `0` when no match is found.

Behaviour for images and SVGs is unchanged; non-image uploads now store `width`/`height` of `0` instead of crashing.